### PR TITLE
Several bug fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,20 @@
 name: test
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Setup Lua
-      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -19,8 +22,11 @@ jobs:
       name: Run luacheck
       run: |
         luacheck .
+
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
@@ -31,15 +37,15 @@ jobs:
           - "lj-v2.1:latest"
     steps:
     -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
+    -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: mah0x211/setup-lua@v1
-      with:
-        versions: ${{ matrix.lua-version }}
     -
       name: Install
       run: |
@@ -47,7 +53,7 @@ jobs:
     -
       name: Install Tools
       run: |
-        sudo apt install lcov -y
+        apt install lcov -y
         luarocks install assert
     -
       name: Run Test

--- a/src/opendir.c
+++ b/src/opendir.c
@@ -107,177 +107,78 @@ static int gc_lua(lua_State *L)
     return 0;
 }
 
-static int normalize(lua_State *L, char *path, size_t len)
+// Returns the length of the next path segment in [*cur, end).
+// Advances *cur past the segment. *seg points to the start of the segment.
+// Consecutive '/' characters are skipped. Returns 0 at end of string.
+// Does NOT interpret '.' or '..' — passes them through as-is.
+static size_t get_segment(const char **cur, const char *end, const char **seg)
 {
-    int top    = 0;
-    char *head = path;
-    char *tail = path + len;
-    char *p    = head;
+    const char *p = *cur;
 
-CHECK_FIRST:
-    switch (*p) {
-    case '/':
-ADD_SEGMENT:
-        // add segments
-        luaL_checkstack(L, 2, NULL);
-        if ((uintptr_t)head < (uintptr_t)p) {
-            lua_pushlstring(L, head, (uintptr_t)p - (uintptr_t)head);
-            top++;
-        }
-        // add '/'
-        lua_pushliteral(L, "/");
-        top++;
-
-        // skip multiple slashes
-        while (*p == '/') {
-            p++;
-        }
-        head = p;
-        if (*p != '.') {
-            break;
-        }
-
-    case '.':
-        // foud '.' segment
-        if (p[1] == '/' || p[1] == 0) {
-            p += 1;
-        }
-        // found '..' segment
-        else if (p[1] == '.' && (p[2] == '/' || p[2] == 0)) {
-            p += 2;
-            switch (top) {
-            case 1:
-                // remove previous segment if it is not slash
-                if (*lua_tostring(L, 1) != '/') {
-                    lua_settop(L, 0);
-                    top = 0;
-                }
-                break;
-
-            default:
-                // remove previous segment with trailing-slash
-                if (top > 1 && strcmp(lua_tostring(L, -2), "..") != 0) {
-                    lua_pop(L, 2);
-                    top -= 2;
-                    break;
-                }
-
-            case 0:
-                // add '..' segment
-                luaL_checkstack(L, 2, NULL);
-                lua_pushliteral(L, "..");
-                lua_pushliteral(L, "/");
-                top += 2;
-                break;
-            }
-        } else {
-            // allow segments that started with '.' character
-            break;
-        }
-
-        // skip multiple slashes
-        while (*p == '/') {
-            p++;
-        }
-        head = p;
-        goto CHECK_FIRST;
-    }
-
-    // search '/' character
-    while (*p) {
-        if (*p == '/') {
-            goto ADD_SEGMENT;
-        }
+    while (p < end && *p == '/') {
         p++;
     }
-
-    // found NULL before the end of the string
-    if (p != tail) {
-        errno = EILSEQ;
-        return -1;
+    if (p >= end) {
+        *cur = p;
+        return 0;
     }
-
-    // add last-segment
-    if ((uintptr_t)head < (uintptr_t)tail) {
-        luaL_checkstack(L, 1, NULL);
-        lua_pushlstring(L, head, (uintptr_t)tail - (uintptr_t)head);
-        top++;
-    } else if (!top) {
-        errno = EINVAL;
-        return -1;
+    *seg = p;
+    while (p < end && *p != '/') {
+        p++;
     }
-
-    // remove trailing-slash
-    if (top > 1 && *(char *)lua_tostring(L, top) == '/') {
-        lua_pop(L, 1);
-    }
-
-    // check a last segment
-    path = (char *)lua_tostring(L, -1);
-    if (strcmp(path, "/") == 0 || strcmp(path, "..") == 0) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    return 0;
+    *cur = p;
+    return (size_t)(p - *seg);
 }
 
 static int opendir_nofollow(lua_State *L, char *path, size_t len, char *pathbuf,
                             size_t pathbuf_siz)
 {
-    int fd  = -1;
-    int top = 0;
+    const char *cur = path;
+    const char *end = path + len;
+    const char *seg = NULL;
+    size_t slen     = 0;
+    size_t plen     = 0;
+    struct stat buf = {0};
 
-    // check path length
+    if (len == 0) {
+        errno = EINVAL;
+        return -1;
+    }
     if (len > pathbuf_siz) {
         errno = ENAMETOOLONG;
         return -1;
     }
-    // normalize a path
-    path      = memcpy(pathbuf, path, len);
-    path[len] = 0;
-    lua_settop(L, 0);
-    if (normalize(L, path, len) != 0) {
-        return -1;
+
+    // absolute path: seed pathbuf with "/"
+    if (path[0] == '/') {
+        pathbuf[0] = '/';
+        plen       = 1;
     }
-    top = lua_gettop(L);
 
-    // verify the existence of each path segment
-    len = 0;
-    for (int idx = 1; idx <= top; idx++) {
-        size_t slen     = 0;
-        const char *seg = lua_tolstring(L, idx, &slen);
-        struct stat buf = {0};
-
-        memcpy(path + len, seg, slen);
-        len += slen;
-        path[len] = 0;
-        if (idx != top) {
-            switch (slen) {
-            case 2:
-                // ignore '.' and '..' segment
-                if (seg[0] == '.' && seg[2] == '.') {
-                    continue;
-                }
-                break;
-            case 1:
-                if (*seg == '/') {
-                    continue;
-                }
-            }
+    while ((slen = get_segment(&cur, end, &seg)) > 0) {
+        // add separator between pathbuf content and next segment if needed
+        if (plen > 0 && pathbuf[plen - 1] != '/') {
+            pathbuf[plen++] = '/';
         }
+        memcpy(pathbuf + plen, seg, slen);
+        plen += slen;
+        pathbuf[plen] = 0;
 
-        if (lstat(path, &buf) != 0) {
+        if (lstat(pathbuf, &buf) != 0) {
             return -1;
         } else if (!S_ISDIR(buf.st_mode)) {
-            // non directory exists
             errno = ENOTDIR;
             return -1;
         }
     }
 
+    if (plen == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
     lua_settop(L, 0);
-    fd = open(path, O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    int fd = open(pathbuf, O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
     if (fd != -1) {
         DIR **dir = lua_newuserdata(L, sizeof(DIR *));
         if ((*dir = fdopendir(fd))) {
@@ -360,5 +261,6 @@ LUALIB_API int luaopen_opendir(lua_State *L)
     // upvalue 2: path buffer (held by closure until state closes)
     lua_newuserdata(L, pathbuf_siz + 1);
     lua_pushcclosure(L, opendir_lua, 2);
+
     return 1;
 }

--- a/src/opendir.c
+++ b/src/opendir.c
@@ -286,6 +286,7 @@ static int opendir_nofollow(lua_State *L, char *path, size_t len)
             lauxh_setmetatable(L, DIR_MT);
             return 0;
         }
+        close(fd);
     }
     return -1;
 }

--- a/src/opendir.c
+++ b/src/opendir.c
@@ -222,21 +222,19 @@ ADD_SEGMENT:
     return 0;
 }
 
-static size_t PATHBUF_SIZ = PATH_MAX;
-static char *PATHBUF      = NULL;
-
-static int opendir_nofollow(lua_State *L, char *path, size_t len)
+static int opendir_nofollow(lua_State *L, char *path, size_t len, char *pathbuf,
+                            size_t pathbuf_siz)
 {
     int fd  = -1;
     int top = 0;
 
     // check path length
-    if (len > PATHBUF_SIZ) {
+    if (len > pathbuf_siz) {
         errno = ENAMETOOLONG;
         return -1;
     }
     // normalize a path
-    path      = memcpy(PATHBUF, path, len);
+    path      = memcpy(pathbuf, path, len);
     path[len] = 0;
     lua_settop(L, 0);
     if (normalize(L, path, len) != 0) {
@@ -308,9 +306,12 @@ static int opendir_lua(lua_State *L)
     size_t len         = 0;
     const char *path   = lauxh_checklstring(L, 1, &len);
     int follow_symlink = lauxh_optboolean(L, 2, 1);
+    size_t pathbuf_siz = (size_t)lua_tointeger(L, lua_upvalueindex(1));
+    char *pathbuf      = lua_touserdata(L, lua_upvalueindex(2));
 
-    if (follow_symlink ? opendir_follow(L, path) :
-                         opendir_nofollow(L, (char *)path, len)) {
+    if (follow_symlink ?
+            opendir_follow(L, path) :
+            opendir_nofollow(L, (char *)path, len, pathbuf, pathbuf_siz)) {
         lua_pushnil(L);
         lua_errno_new(L, errno, "opendir");
         return 2;
@@ -320,18 +321,10 @@ static int opendir_lua(lua_State *L)
 
 LUALIB_API int luaopen_opendir(lua_State *L)
 {
-    long pathmax = pathconf(".", _PC_PATH_MAX);
+    long pathmax       = pathconf(".", _PC_PATH_MAX);
+    size_t pathbuf_siz = (pathmax != -1) ? (size_t)pathmax : PATH_MAX;
 
     lua_errno_loadlib(L);
-
-    // set the maximum number of bytes in a pathname
-    if (pathmax != -1) {
-        PATHBUF_SIZ = pathmax;
-    }
-    // allocate the buffer for getcwd
-    PATHBUF = lua_newuserdata(L, PATHBUF_SIZ + 1);
-    // holds until the state closes
-    luaL_ref(L, LUA_REGISTRYINDEX);
 
     // create metatable
     if (luaL_newmetatable(L, DIR_MT)) {
@@ -362,6 +355,10 @@ LUALIB_API int luaopen_opendir(lua_State *L)
         lua_pop(L, 1);
     }
 
-    lua_pushcfunction(L, opendir_lua);
+    // upvalue 1: path buffer size
+    lua_pushinteger(L, (lua_Integer)pathbuf_siz);
+    // upvalue 2: path buffer (held by closure until state closes)
+    lua_newuserdata(L, pathbuf_siz + 1);
+    lua_pushcclosure(L, opendir_lua, 2);
     return 1;
 }

--- a/src/opendir.c
+++ b/src/opendir.c
@@ -23,9 +23,6 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <limits.h>
-#include <string.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 // lua
@@ -107,124 +104,39 @@ static int gc_lua(lua_State *L)
     return 0;
 }
 
-// Returns the length of the next path segment in [*cur, end).
-// Advances *cur past the segment. *seg points to the start of the segment.
-// Consecutive '/' characters are skipped. Returns 0 at end of string.
-// Does NOT interpret '.' or '..' — passes them through as-is.
-static size_t get_segment(const char **cur, const char *end, const char **seg)
-{
-    const char *p = *cur;
-
-    while (p < end && *p == '/') {
-        p++;
-    }
-    if (p >= end) {
-        *cur = p;
-        return 0;
-    }
-    *seg = p;
-    while (p < end && *p != '/') {
-        p++;
-    }
-    *cur = p;
-    return (size_t)(p - *seg);
-}
-
-static int opendir_nofollow(lua_State *L, char *path, size_t len, char *pathbuf,
-                            size_t pathbuf_siz)
-{
-    const char *cur = path;
-    const char *end = path + len;
-    const char *seg = NULL;
-    size_t slen     = 0;
-    size_t plen     = 0;
-    struct stat buf = {0};
-
-    if (len == 0) {
-        errno = EINVAL;
-        return -1;
-    }
-    if (len > pathbuf_siz) {
-        errno = ENAMETOOLONG;
-        return -1;
-    }
-
-    // absolute path: seed pathbuf with "/"
-    if (path[0] == '/') {
-        pathbuf[0] = '/';
-        plen       = 1;
-    }
-
-    while ((slen = get_segment(&cur, end, &seg)) > 0) {
-        // add separator between pathbuf content and next segment if needed
-        if (plen > 0 && pathbuf[plen - 1] != '/') {
-            pathbuf[plen++] = '/';
-        }
-        memcpy(pathbuf + plen, seg, slen);
-        plen += slen;
-        pathbuf[plen] = 0;
-
-        if (lstat(pathbuf, &buf) != 0) {
-            return -1;
-        } else if (!S_ISDIR(buf.st_mode)) {
-            errno = ENOTDIR;
-            return -1;
-        }
-    }
-
-    if (plen == 0) {
-        errno = EINVAL;
-        return -1;
-    }
-
-    lua_settop(L, 0);
-    int fd = open(pathbuf, O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
-    if (fd != -1) {
-        DIR **dir = lua_newuserdata(L, sizeof(DIR *));
-        if ((*dir = fdopendir(fd))) {
-            lauxh_setmetatable(L, DIR_MT);
-            return 0;
-        }
-        close(fd);
-    }
-    return -1;
-}
-
-static int opendir_follow(lua_State *L, const char *path)
-{
-    DIR **dir = lua_newuserdata(L, sizeof(DIR *));
-
-    if ((*dir = opendir(path))) {
-        luaL_getmetatable(L, DIR_MT);
-        lua_setmetatable(L, -2);
-        return 0;
-    }
-    return -1;
-}
-
 static int opendir_lua(lua_State *L)
 {
     size_t len         = 0;
     const char *path   = lauxh_checklstring(L, 1, &len);
     int follow_symlink = lauxh_optboolean(L, 2, 1);
-    size_t pathbuf_siz = (size_t)lua_tointeger(L, lua_upvalueindex(1));
-    char *pathbuf      = lua_touserdata(L, lua_upvalueindex(2));
 
-    if (follow_symlink ?
-            opendir_follow(L, path) :
-            opendir_nofollow(L, (char *)path, len, pathbuf, pathbuf_siz)) {
-        lua_pushnil(L);
-        lua_errno_new(L, errno, "opendir");
-        return 2;
+    if (follow_symlink) {
+        DIR **dir = lua_newuserdata(L, sizeof(DIR *));
+        if ((*dir = opendir(path))) {
+            luaL_getmetatable(L, DIR_MT);
+            lua_setmetatable(L, -2);
+            return 1;
+        }
+    } else {
+        // POSIX: O_NOFOLLOW applies to the final path component only
+        int fd = open(path, O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+        if (fd != -1) {
+            DIR **dir = lua_newuserdata(L, sizeof(DIR *));
+            if ((*dir = fdopendir(fd))) {
+                lauxh_setmetatable(L, DIR_MT);
+                return 1;
+            }
+            close(fd);
+        }
     }
-    return 1;
+
+    lua_pushnil(L);
+    lua_errno_new(L, errno, "opendir");
+    return 2;
 }
 
 LUALIB_API int luaopen_opendir(lua_State *L)
 {
-    long pathmax       = pathconf(".", _PC_PATH_MAX);
-    size_t pathbuf_siz = (pathmax != -1) ? (size_t)pathmax : PATH_MAX;
-
     lua_errno_loadlib(L);
 
     // create metatable
@@ -256,11 +168,7 @@ LUALIB_API int luaopen_opendir(lua_State *L)
         lua_pop(L, 1);
     }
 
-    // upvalue 1: path buffer size
-    lua_pushinteger(L, (lua_Integer)pathbuf_siz);
-    // upvalue 2: path buffer (held by closure until state closes)
-    lua_newuserdata(L, pathbuf_siz + 1);
-    lua_pushcclosure(L, opendir_lua, 2);
+    lua_pushcfunction(L, opendir_lua);
 
     return 1;
 }

--- a/test/opendir_test.lua
+++ b/test/opendir_test.lua
@@ -61,8 +61,14 @@ local function test_opendir_nofollow()
     assert.match(tostring(dir), 'dir: ')
     assert(dir:closedir())
 
-    -- test that cannot get directory stream from symlink
+    -- test that follows intermediate symlinks (O_NOFOLLOW is final-component only)
     dir, err = opendir('./test/testdir_symlink/bardir', false)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert(dir:closedir())
+
+    -- test that rejects symlink as the final path component
+    dir, err = opendir('./test/testdir_symlink', false)
     assert.is_nil(dir)
     assert.equal(err.type, errno.ENOTDIR)
 

--- a/test/opendir_test.lua
+++ b/test/opendir_test.lua
@@ -33,8 +33,29 @@ local function test_opendir_nofollow()
     assert.match(tostring(dir), 'dir: ')
     assert(dir:closedir())
 
-    -- test that get directory stream
-    dir, err = assert(opendir('./test/testdir/foo/../bar/..', false))
+    -- test that get directory stream with ".." traversal via real directories
+    dir, err = assert(opendir('./test/testdir/bardir/..', false))
+    assert(dir, err)
+    assert.is_nil(err)
+    assert.match(tostring(dir), 'dir: ')
+    assert(dir:closedir())
+
+    -- test that get directory stream from "."
+    dir, err = opendir('.', false)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert.match(tostring(dir), 'dir: ')
+    assert(dir:closedir())
+
+    -- test that get directory stream from ".."
+    dir, err = opendir('..', false)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert.match(tostring(dir), 'dir: ')
+    assert(dir:closedir())
+
+    -- test that get directory stream from "/"
+    dir, err = opendir('/', false)
     assert(dir, err)
     assert.is_nil(err)
     assert.match(tostring(dir), 'dir: ')


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for testing and significantly simplifies the implementation of the `opendir` function in `src/opendir.c` by removing custom path normalization and directory traversal logic. The new implementation relies directly on POSIX semantics for handling symlinks and directory opening, which improves maintainability and correctness. Corresponding tests have been added and updated to reflect the new behavior.

**Workflow improvements:**

- **CI job enhancements:** The GitHub Actions workflow now uses a pre-built container image (`ghcr.io/mah0x211/lua-ci:latest`) for both `luacheck` and `test` jobs, and only triggers on code changes (excluding `.md` and `LICENSE` files). The workflow also switches Lua versions using `lenv` and removes unnecessary setup steps. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-R29) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R39-R56)

**Code simplification and correctness:**

- **Simplified `opendir` implementation:** The custom path normalization and directory segment traversal logic in `src/opendir.c` has been removed. The `opendir_lua` function now uses POSIX's `O_NOFOLLOW` flag directly, ensuring that only the final path component is checked for symlinks, aligning with standard behavior.
- **Removed unused includes:** Unused headers such as `<limits.h>`, `<string.h>`, and `<sys/stat.h>` were removed from `src/opendir.c`.

**Test improvements:**

- **Expanded test coverage:** The test suite now covers additional cases, including opening `"."`, `".."`, and `"/"`, and verifies correct handling of symlinks both as intermediate and final path components. Tests confirm that the function follows POSIX semantics regarding symlink handling.

**Other:**

- **Minor code cleanup:** Unused buffer allocation and path length checks were removed from the Lua C module initialization. [[1]](diffhunk://#diff-504de86f89b7973917eff669da61845eb01728a395ee14e47c863e304399a29aL110-L334) [[2]](diffhunk://#diff-504de86f89b7973917eff669da61845eb01728a395ee14e47c863e304399a29aR172)