### PR TITLE
Add toctou parameter for TOCTOU-safe directory traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dir:closedir()
 the following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## dir, err = opendir( name [, follow_symlink] )
+## dir, err = opendir( name [, follow_symlink [, toctou]] )
 
 open a directory stream corresponding to the directory `name`.
 
@@ -40,6 +40,20 @@ open a directory stream corresponding to the directory `name`.
 
 - `name:string`: directory name.
 - `follow_symlink:boolean`: follow symbolic links. (default: `true`)
+  - `true`: symbolic links are followed at all path components.
+  - `false`: symbolic link at the final path component is rejected (`ENOTDIR`). Intermediate symbolic links are still followed (POSIX `O_NOFOLLOW` semantics).
+- `toctou:boolean`: enable TOCTOU-safe traversal via `openat(2)`. (default: `false`)
+  - When `true`, each path segment is opened with `openat(2)` relative to the previously opened directory file descriptor, eliminating the race window between path resolution steps.
+  - When `follow_symlink=false`, `O_NOFOLLOW` is passed to every `openat(2)` call, so symbolic links at any position are rejected (`ENOTDIR`).
+
+**Behavior by parameter combination**
+
+| `follow_symlink` | `toctou` | symlink behavior |
+|:---:|:---:|---|
+| `true` | `false` | all symbolic links are followed |
+| `true` | `true` | all symbolic links are followed, TOCTOU-safe |
+| `false` | `false` | intermediate symbolic links followed; final component rejected (`ENOTDIR`) |
+| `false` | `true` | symbolic links at all positions rejected (`ENOTDIR`) |
 
 **Returns**
 

--- a/src/opendir.c
+++ b/src/opendir.c
@@ -23,6 +23,8 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
 // lua
@@ -104,13 +106,100 @@ static int gc_lua(lua_State *L)
     return 0;
 }
 
+// Returns the length of the next path segment in [*cur, end).
+// Advances *cur past the segment. *seg points to the start of the segment.
+// Consecutive '/' characters are skipped. Returns 0 at end of string.
+// Does NOT interpret '.' or '..' — passes them through as-is.
+static size_t get_segment(const char **cur, const char *end, const char **seg)
+{
+    const char *p = *cur;
+
+    while (p < end && *p == '/') {
+        p++;
+    }
+    if (p >= end) {
+        *cur = p;
+        return 0;
+    }
+    *seg = p;
+    while (p < end && *p != '/') {
+        p++;
+    }
+    *cur = p;
+    return (size_t)(p - *seg);
+}
+
+// Opens a directory by traversing path one segment at a time using openat(2).
+// When nofollow is non-zero, O_NOFOLLOW is passed to every openat call so
+// that symlinks at any position in the path are rejected with ENOTDIR.
+// When nofollow is zero, symlinks are followed at every position.
+// Each openat call is atomic with respect to the previously opened fd,
+// providing TOCTOU safety for the traversed prefix.
+static int opendir_toctou(lua_State *L, char *path, size_t len, char *pathbuf,
+                          size_t pathbuf_siz, int nofollow)
+{
+    const char *cur = path;
+    const char *end = path + len;
+    const char *seg = NULL;
+    size_t slen     = 0;
+    int flags       = O_DIRECTORY | O_CLOEXEC | (nofollow ? O_NOFOLLOW : 0);
+    int dirfd       = AT_FDCWD;
+
+    if (len == 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (len > pathbuf_siz) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    if (path[0] == '/') {
+        dirfd = open("/", flags);
+        if (dirfd < 0) {
+            return -1;
+        }
+    }
+
+    while ((slen = get_segment(&cur, end, &seg)) > 0) {
+        int newfd;
+        memcpy(pathbuf, seg, slen);
+        pathbuf[slen] = '\0';
+        newfd         = openat(dirfd, pathbuf, flags);
+        if (dirfd != AT_FDCWD) {
+            close(dirfd);
+        }
+        dirfd = newfd;
+        if (dirfd < 0) {
+            return -1;
+        }
+    }
+
+    lua_settop(L, 0);
+    DIR **dir = lua_newuserdata(L, sizeof(DIR *));
+    if ((*dir = fdopendir(dirfd))) {
+        lauxh_setmetatable(L, DIR_MT);
+        return 0;
+    }
+    close(dirfd);
+    return -1;
+}
+
 static int opendir_lua(lua_State *L)
 {
     size_t len         = 0;
     const char *path   = lauxh_checklstring(L, 1, &len);
     int follow_symlink = lauxh_optboolean(L, 2, 1);
+    int toctou         = lauxh_optboolean(L, 3, 0);
+    size_t pathbuf_siz = (size_t)lua_tointeger(L, lua_upvalueindex(1));
+    char *pathbuf      = lua_touserdata(L, lua_upvalueindex(2));
 
-    if (follow_symlink) {
+    if (toctou) {
+        if (opendir_toctou(L, (char *)path, len, pathbuf, pathbuf_siz,
+                           !follow_symlink) == 0) {
+            return 1;
+        }
+    } else if (follow_symlink) {
         DIR **dir = lua_newuserdata(L, sizeof(DIR *));
         if ((*dir = opendir(path))) {
             luaL_getmetatable(L, DIR_MT);
@@ -137,6 +226,9 @@ static int opendir_lua(lua_State *L)
 
 LUALIB_API int luaopen_opendir(lua_State *L)
 {
+    long pathmax       = pathconf(".", _PC_PATH_MAX);
+    size_t pathbuf_siz = (pathmax != -1) ? (size_t)pathmax : PATH_MAX;
+
     lua_errno_loadlib(L);
 
     // create metatable
@@ -168,7 +260,11 @@ LUALIB_API int luaopen_opendir(lua_State *L)
         lua_pop(L, 1);
     }
 
-    lua_pushcfunction(L, opendir_lua);
+    // upvalue 1: path buffer size
+    lua_pushinteger(L, (lua_Integer)pathbuf_siz);
+    // upvalue 2: path buffer (held by closure until state closes)
+    lua_newuserdata(L, pathbuf_siz + 1);
+    lua_pushcclosure(L, opendir_lua, 2);
 
     return 1;
 }

--- a/test/opendir_test.lua
+++ b/test/opendir_test.lua
@@ -73,13 +73,85 @@ local function test_opendir_nofollow()
     assert.equal(err.type, errno.ENOTDIR)
 
     -- test that return ENAMETOOLONG error
-    dir, err = opendir(string.rep('x', 4096), false)
+    dir, err = opendir(string.rep('x', 65536), false)
     assert.is_nil(dir)
     assert.equal(err.type, errno.ENAMETOOLONG)
 
     -- test that throws an error
     err = assert.throws(opendir, './test/testdir', {})
     assert.match(err, '#2 .+ [(]boolean expected', false)
+end
+
+local function test_opendir_toctou()
+    -- follow_symlink=true, toctou=true: basic directory
+    local dir, err = opendir('./test/testdir', true, true)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert.match(tostring(dir), 'dir: ')
+    assert(dir:closedir())
+
+    -- follow_symlink=true, toctou=true: follow intermediate symlink
+    dir, err = opendir('./test/testdir_symlink/bardir', true, true)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert(dir:closedir())
+
+    -- follow_symlink=true, toctou=true: ENAMETOOLONG
+    dir, err = opendir(string.rep('x', 65536), true, true)
+    assert.is_nil(dir)
+    assert.equal(err.type, errno.ENAMETOOLONG)
+
+    -- follow_symlink=false, toctou=true: basic directory
+    dir, err = opendir('./test/testdir', false, true)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert(dir:closedir())
+
+    -- follow_symlink=false, toctou=true: ".", "..", "/"
+    dir, err = opendir('.', false, true)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert(dir:closedir())
+
+    dir, err = opendir('..', false, true)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert(dir:closedir())
+
+    dir, err = opendir('/', false, true)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert(dir:closedir())
+
+    -- follow_symlink=false, toctou=true: ".." traversal via real directory
+    dir, err = opendir('./test/testdir/bardir/..', false, true)
+    assert(dir, err)
+    assert.is_nil(err)
+    assert(dir:closedir())
+
+    -- follow_symlink=false, toctou=true: reject symlink at intermediate position
+    dir, err = opendir('./test/testdir_symlink/bardir', false, true)
+    assert.is_nil(dir)
+    assert.equal(err.type, errno.ENOTDIR)
+
+    -- follow_symlink=false, toctou=true: ENAMETOOLONG
+    dir, err = opendir(string.rep('x', 65536), false, true)
+    assert.is_nil(dir)
+    assert.equal(err.type, errno.ENAMETOOLONG)
+
+    -- follow_symlink=true, toctou=true: EINVAL on empty path
+    dir, err = opendir('', true, true)
+    assert.is_nil(dir)
+    assert.equal(err.type, errno.EINVAL)
+
+    -- follow_symlink=false, toctou=true: EINVAL on empty path
+    dir, err = opendir('', false, true)
+    assert.is_nil(dir)
+    assert.equal(err.type, errno.EINVAL)
+
+    -- test that throws an error on invalid third argument
+    err = assert.throws(opendir, './test/testdir', true, {})
+    assert.match(err, '#3 .+ [(]boolean expected', false)
 end
 
 local function test_closedir()
@@ -158,6 +230,7 @@ end
 for _, fn in ipairs({
     test_opendir,
     test_opendir_nofollow,
+    test_opendir_toctou,
     test_closedir,
     test_readdir,
     test_rewinddir,


### PR DESCRIPTION
This pull request adds support for TOCTOU-safe (time-of-check to time-of-use) directory opening in the `opendir` Lua binding by introducing a new `toctou` parameter. It implements path traversal using `openat(2)` for each segment, ensuring atomicity and reducing race condition risks. The documentation and test suite are updated to reflect and verify this new functionality.

**TOCTOU-safe directory opening:**

* Added a new optional `toctou` boolean parameter to `opendir`, enabling TOCTOU-safe traversal using `openat(2)` for each path segment. When enabled, symbolic link handling is stricter and more secure, with detailed behavior depending on the combination of `follow_symlink` and `toctou` values. (`README.md`, `src/opendir.c`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R56) [[2]](diffhunk://#diff-504de86f89b7973917eff669da61845eb01728a395ee14e47c863e304399a29aR109-R207)

* Implemented the `opendir_toctou` function in C, which atomically opens each directory segment with `openat(2)`, optionally passing `O_NOFOLLOW` to reject symlinks at any position for maximum safety. (`src/opendir.c`)

**API and documentation updates:**

* Updated the documentation to describe the new parameter, its default value, and the detailed behavior matrix for all parameter combinations. (`README.md`)

**Testing:**

* Added comprehensive test cases for the new `toctou` parameter, covering various combinations of `follow_symlink` and `toctou`, including symlink rejection, ENAMETOOLONG errors, and argument validation. (`test/opendir_test.lua`) [[1]](diffhunk://#diff-4de6effac2cbee1913c48398723dec8ed78032f7009a383e11897d5d07bbd91cR85-R146) [[2]](diffhunk://#diff-4de6effac2cbee1913c48398723dec8ed78032f7009a383e11897d5d07bbd91cR223)

**Internal improvements:**

* Allocated a reusable path buffer for use in TOCTOU-safe traversal, passed as upvalues to the Lua C closure for efficiency. (`src/opendir.c`) [[1]](diffhunk://#diff-504de86f89b7973917eff669da61845eb01728a395ee14e47c863e304399a29aR234-R236) [[2]](diffhunk://#diff-504de86f89b7973917eff669da61845eb01728a395ee14e47c863e304399a29aL171-R272)

These changes enhance the security and robustness of directory opening, especially in environments where race conditions or symlink attacks are a concern.